### PR TITLE
updated path to .deb package

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ dpkg -i konfigadm.deb
 ### Centos / Fedora / Redhat
 
 ```bash
-rpm -i https://github.com/moshloop/konfigadm/releases/download/v0.4.2/konfigadm.rpm
+rpm -i https://github.com/flanksource/konfigadm/releases/download/v0.4.2/konfigadm.rpm
 ```
 
 ### Binary
 
 ```bash
-wget -O /usr/bin/konfigadm https://github.com/moshloop/konfigadm/releases/download/v0.4.2/konfigadm && chmod +x /usr/bin/konfigadm
+wget -O /usr/bin/konfigadm https://github.com/flanksource/konfigadm/releases/download/v0.4.2/konfigadm && sudo chmod +x /usr/bin/konfigadm
 ```
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Flags:
 ### Ubuntu / Debian
 
 ```bash
-wget https://github.com/moshloop/konfigadm/releases/download/v0.4.2/konfigadm.deb
+wget https://github.com/flanksource/konfigadm/releases/download/v0.4.2/konfigadm.deb
 dpkg -i konfigadm.deb
 ```
 


### PR DESCRIPTION
This is a minor edit on the installation steps for Ubuntu OS. The path to the Debian package exists in the flanksource repo not the moshloop repo.