### PR TITLE
change import references to flanksource/konfigadm repository

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/moshloop/konfigadm/pkg/utils"
+	"github.com/flanksource/konfigadm/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cmd/cloud-init.go
+++ b/cmd/cloud-init.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	cloudinit "github.com/moshloop/konfigadm/pkg/cloud-init"
+	cloudinit "github.com/flanksource/konfigadm/pkg/cloud-init"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -3,9 +3,9 @@ package cmd
 import (
 	"os"
 
-	_ "github.com/moshloop/konfigadm/pkg"
-	"github.com/moshloop/konfigadm/pkg/phases"
-	"github.com/moshloop/konfigadm/pkg/types"
+	_ "github.com/flanksource/konfigadm/pkg"
+	"github.com/flanksource/konfigadm/pkg/phases"
+	"github.com/flanksource/konfigadm/pkg/types"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/cmd/image_aliases.go
+++ b/cmd/image_aliases.go
@@ -1,8 +1,8 @@
 package cmd
 
 import (
-	"github.com/moshloop/konfigadm/pkg/types"
-	"github.com/moshloop/konfigadm/pkg/utils"
+	"github.com/flanksource/konfigadm/pkg/types"
+	"github.com/flanksource/konfigadm/pkg/utils"
 )
 
 var images = map[string]Image{

--- a/cmd/images.go
+++ b/cmd/images.go
@@ -6,12 +6,12 @@ import (
 	"path"
 	"strings"
 
-	"github.com/moshloop/konfigadm/pkg/build/ova"
-	"github.com/moshloop/konfigadm/pkg/types"
+	"github.com/flanksource/konfigadm/pkg/build/ova"
+	"github.com/flanksource/konfigadm/pkg/types"
 
-	. "github.com/moshloop/konfigadm/pkg/build"
+	. "github.com/flanksource/konfigadm/pkg/build"
 
-	"github.com/moshloop/konfigadm/pkg/utils"
+	"github.com/flanksource/konfigadm/pkg/utils"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/spf13/cobra"

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"os"
 
-	"github.com/moshloop/konfigadm/pkg/types"
+	"github.com/flanksource/konfigadm/pkg/types"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/moshloop/konfigadm
+module github.com/flanksource/konfigadm
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/moshloop/konfigadm/cmd"
+	"github.com/flanksource/konfigadm/cmd"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )

--- a/pkg/apps/cleanup.go
+++ b/pkg/apps/cleanup.go
@@ -1,9 +1,9 @@
 package apps
 
 import (
-	"github.com/moshloop/konfigadm/pkg/build"
-	"github.com/moshloop/konfigadm/pkg/phases"
-	. "github.com/moshloop/konfigadm/pkg/types"
+	"github.com/flanksource/konfigadm/pkg/build"
+	"github.com/flanksource/konfigadm/pkg/phases"
+	. "github.com/flanksource/konfigadm/pkg/types"
 )
 
 var Cleanup Phase = cleanup{}

--- a/pkg/apps/cni.go
+++ b/pkg/apps/cni.go
@@ -1,7 +1,7 @@
 package apps
 
 import (
-	. "github.com/moshloop/konfigadm/pkg/types"
+	. "github.com/flanksource/konfigadm/pkg/types"
 )
 
 var CNI Phase = cni{}

--- a/pkg/apps/cri.go
+++ b/pkg/apps/cri.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/moshloop/konfigadm/pkg/phases"
-	. "github.com/moshloop/konfigadm/pkg/types"
-	"github.com/moshloop/konfigadm/pkg/utils"
+	"github.com/flanksource/konfigadm/pkg/phases"
+	. "github.com/flanksource/konfigadm/pkg/types"
+	"github.com/flanksource/konfigadm/pkg/utils"
 )
 
 var CRI Phase = cri{}

--- a/pkg/apps/kubernetes.go
+++ b/pkg/apps/kubernetes.go
@@ -3,7 +3,7 @@ package apps
 import (
 	"strings"
 
-	. "github.com/moshloop/konfigadm/pkg/types"
+	. "github.com/flanksource/konfigadm/pkg/types"
 )
 
 var Kubernetes Phase = kubernetes{}

--- a/pkg/apps/kubernetes_test.go
+++ b/pkg/apps/kubernetes_test.go
@@ -1,10 +1,10 @@
 package apps_test
 
 import (
+	_ "github.com/flanksource/konfigadm/pkg"
+	. "github.com/flanksource/konfigadm/pkg/types"
+	. "github.com/onsi/gomega"
 	"testing"
-	_ "github.com/moshloop/konfigadm/pkg"
-	. "github.com/moshloop/konfigadm/pkg/types"
-	."github.com/onsi/gomega"
 )
 
 func TestMarkPackages(t *testing.T) {

--- a/pkg/build/driver.go
+++ b/pkg/build/driver.go
@@ -3,8 +3,8 @@ package build
 import (
 	"strings"
 
-	cloudinit "github.com/moshloop/konfigadm/pkg/cloud-init"
-	"github.com/moshloop/konfigadm/pkg/types"
+	cloudinit "github.com/flanksource/konfigadm/pkg/cloud-init"
+	"github.com/flanksource/konfigadm/pkg/types"
 )
 
 type Driver interface {

--- a/pkg/build/libguestfs.go
+++ b/pkg/build/libguestfs.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"path"
 
+	"github.com/flanksource/konfigadm/pkg/types"
+	"github.com/flanksource/konfigadm/pkg/utils"
 	"github.com/mitchellh/colorstring"
-	"github.com/moshloop/konfigadm/pkg/types"
-	"github.com/moshloop/konfigadm/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 )

--- a/pkg/build/ova/ova.go
+++ b/pkg/build/ova/ova.go
@@ -11,7 +11,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/moshloop/konfigadm/pkg/utils"
+	"github.com/flanksource/konfigadm/pkg/utils"
 )
 
 var (

--- a/pkg/build/ova/upload.go
+++ b/pkg/build/ova/upload.go
@@ -6,7 +6,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/moshloop/konfigadm/pkg/utils"
+	"github.com/flanksource/konfigadm/pkg/utils"
 )
 
 var (

--- a/pkg/build/qemu.go
+++ b/pkg/build/qemu.go
@@ -6,8 +6,8 @@ import (
 	"github.com/mitchellh/colorstring"
 	log "github.com/sirupsen/logrus"
 
-	"github.com/moshloop/konfigadm/pkg/types"
-	"github.com/moshloop/konfigadm/pkg/utils"
+	"github.com/flanksource/konfigadm/pkg/types"
+	"github.com/flanksource/konfigadm/pkg/utils"
 )
 
 type Qemu struct{}

--- a/pkg/build/scratch.go
+++ b/pkg/build/scratch.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/moshloop/konfigadm/pkg/utils"
+	"github.com/flanksource/konfigadm/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/cloud-init/iso.go
+++ b/pkg/cloud-init/iso.go
@@ -8,7 +8,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/moshloop/konfigadm/pkg/utils"
+	"github.com/flanksource/konfigadm/pkg/utils"
 )
 
 //CreateISO creates a new ISO with the user/meta data and returns a path to the iso

--- a/pkg/phases.go
+++ b/pkg/phases.go
@@ -1,9 +1,9 @@
 package pkg
 
 import (
-	"github.com/moshloop/konfigadm/pkg/apps"
-	"github.com/moshloop/konfigadm/pkg/phases"
-	"github.com/moshloop/konfigadm/pkg/types"
+	"github.com/flanksource/konfigadm/pkg/apps"
+	"github.com/flanksource/konfigadm/pkg/phases"
+	"github.com/flanksource/konfigadm/pkg/types"
 )
 
 func init() {

--- a/pkg/phases/apt.go
+++ b/pkg/phases/apt.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	. "github.com/moshloop/konfigadm/pkg/types"
-	"github.com/moshloop/konfigadm/pkg/utils"
+	. "github.com/flanksource/konfigadm/pkg/types"
+	"github.com/flanksource/konfigadm/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/phases/commands.go
+++ b/pkg/phases/commands.go
@@ -1,7 +1,7 @@
 package phases
 
 import (
-	. "github.com/moshloop/konfigadm/pkg/types"
+	. "github.com/flanksource/konfigadm/pkg/types"
 )
 
 var CommandsPhase AllPhases = command{}

--- a/pkg/phases/commands_test.go
+++ b/pkg/phases/commands_test.go
@@ -3,7 +3,7 @@ package phases_test
 import (
 	"testing"
 
-	. "github.com/moshloop/konfigadm/pkg/types"
+	. "github.com/flanksource/konfigadm/pkg/types"
 	"github.com/onsi/gomega"
 )
 

--- a/pkg/phases/containers.go
+++ b/pkg/phases/containers.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	. "github.com/moshloop/konfigadm/pkg/types"
+	. "github.com/flanksource/konfigadm/pkg/types"
 )
 
 var Containers Phase = containers{}

--- a/pkg/phases/containers_test.go
+++ b/pkg/phases/containers_test.go
@@ -2,8 +2,8 @@ package phases_test
 
 import (
 	"testing"
-	_ "github.com/moshloop/konfigadm/pkg"
-	. "github.com/moshloop/konfigadm/pkg/types"
+	_ "github.com/flanksource/konfigadm/pkg"
+	. "github.com/flanksource/konfigadm/pkg/types"
 	"github.com/onsi/gomega"
 )
 

--- a/pkg/phases/context.go
+++ b/pkg/phases/context.go
@@ -7,8 +7,8 @@ import (
 	"github.com/flosch/pongo2"
 	log "github.com/sirupsen/logrus"
 
-	. "github.com/moshloop/konfigadm/pkg/types"
-	. "github.com/moshloop/konfigadm/pkg/utils"
+	. "github.com/flanksource/konfigadm/pkg/types"
+	. "github.com/flanksource/konfigadm/pkg/utils"
 )
 
 var Context Phase = context{}

--- a/pkg/phases/context_test.go
+++ b/pkg/phases/context_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/onsi/gomega"
 
-	. "github.com/moshloop/konfigadm/pkg/types"
+	. "github.com/flanksource/konfigadm/pkg/types"
 )
 
 func TestArgs(t *testing.T) {

--- a/pkg/phases/debian.go
+++ b/pkg/phases/debian.go
@@ -3,8 +3,8 @@ package phases
 import (
 	"strings"
 
-	. "github.com/moshloop/konfigadm/pkg/types"
-	"github.com/moshloop/konfigadm/pkg/utils"
+	. "github.com/flanksource/konfigadm/pkg/types"
+	"github.com/flanksource/konfigadm/pkg/utils"
 )
 
 var (

--- a/pkg/phases/dnf.go
+++ b/pkg/phases/dnf.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	. "github.com/moshloop/konfigadm/pkg/types"
-	"github.com/moshloop/konfigadm/pkg/utils"
+	. "github.com/flanksource/konfigadm/pkg/types"
+	"github.com/flanksource/konfigadm/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/phases/environment.go
+++ b/pkg/phases/environment.go
@@ -1,8 +1,8 @@
 package phases
 
 import (
-	. "github.com/moshloop/konfigadm/pkg/types"
-	"github.com/moshloop/konfigadm/pkg/utils"
+	. "github.com/flanksource/konfigadm/pkg/types"
+	"github.com/flanksource/konfigadm/pkg/utils"
 )
 
 var Environment Phase = environment{}

--- a/pkg/phases/files.go
+++ b/pkg/phases/files.go
@@ -4,7 +4,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	. "github.com/moshloop/konfigadm/pkg/types"
+	. "github.com/flanksource/konfigadm/pkg/types"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/phases/files_test.go
+++ b/pkg/phases/files_test.go
@@ -1,10 +1,10 @@
 package phases_test
 
 import (
+	. "github.com/flanksource/konfigadm/pkg/types"
+	"github.com/onsi/gomega"
 	"io/ioutil"
 	"testing"
-	. "github.com/moshloop/konfigadm/pkg/types"
-	"github.com/onsi/gomega"
 )
 
 func TestCopy(t *testing.T) {

--- a/pkg/phases/os.go
+++ b/pkg/phases/os.go
@@ -3,7 +3,7 @@ package phases
 import (
 	"fmt"
 
-	. "github.com/moshloop/konfigadm/pkg/types"
+	. "github.com/flanksource/konfigadm/pkg/types"
 )
 
 //OS provides an abstraction over different operating systems

--- a/pkg/phases/packages.go
+++ b/pkg/phases/packages.go
@@ -6,8 +6,8 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	. "github.com/moshloop/konfigadm/pkg/types"
-	"github.com/moshloop/konfigadm/pkg/utils"
+	. "github.com/flanksource/konfigadm/pkg/types"
+	"github.com/flanksource/konfigadm/pkg/utils"
 )
 
 var Packages AllPhases = packages{}

--- a/pkg/phases/packages_test.go
+++ b/pkg/phases/packages_test.go
@@ -3,7 +3,7 @@ package phases_test
 import (
 	"testing"
 
-	. "github.com/moshloop/konfigadm/pkg/types"
+	. "github.com/flanksource/konfigadm/pkg/types"
 )
 
 func init() {

--- a/pkg/phases/redhat.go
+++ b/pkg/phases/redhat.go
@@ -3,8 +3,8 @@ package phases
 import (
 	"strings"
 
-	. "github.com/moshloop/konfigadm/pkg/types"
-	"github.com/moshloop/konfigadm/pkg/utils"
+	. "github.com/flanksource/konfigadm/pkg/types"
+	"github.com/flanksource/konfigadm/pkg/utils"
 )
 
 var (

--- a/pkg/phases/services.go
+++ b/pkg/phases/services.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	. "github.com/moshloop/konfigadm/pkg/types"
-	"github.com/moshloop/konfigadm/pkg/utils"
+	. "github.com/flanksource/konfigadm/pkg/types"
+	"github.com/flanksource/konfigadm/pkg/utils"
 )
 
 var Services Phase = services{}

--- a/pkg/phases/sysctl.go
+++ b/pkg/phases/sysctl.go
@@ -5,9 +5,9 @@ import (
 	"os"
 	"strings"
 
-	. "github.com/moshloop/konfigadm/pkg/types"
+	. "github.com/flanksource/konfigadm/pkg/types"
 
-	. "github.com/moshloop/konfigadm/pkg/utils"
+	. "github.com/flanksource/konfigadm/pkg/utils"
 )
 
 var Sysctl Phase = sysctl{}

--- a/pkg/phases/sysctl_test.go
+++ b/pkg/phases/sysctl_test.go
@@ -3,7 +3,7 @@ package phases_test
 import (
 	"testing"
 
-	. "github.com/moshloop/konfigadm/pkg/types"
+	. "github.com/flanksource/konfigadm/pkg/types"
 	"github.com/onsi/gomega"
 )
 

--- a/pkg/phases/yum.go
+++ b/pkg/phases/yum.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	. "github.com/moshloop/konfigadm/pkg/types"
-	"github.com/moshloop/konfigadm/pkg/utils"
+	. "github.com/flanksource/konfigadm/pkg/types"
+	"github.com/flanksource/konfigadm/pkg/utils"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/pkg/types/config.go
+++ b/pkg/types/config.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"strings"
 
-	cloudinit "github.com/moshloop/konfigadm/pkg/cloud-init"
+	cloudinit "github.com/flanksource/konfigadm/pkg/cloud-init"
 	log "github.com/sirupsen/logrus"
 	"go.uber.org/dig"
 	yaml "gopkg.in/yaml.v3"

--- a/pkg/types/systemd.go
+++ b/pkg/types/systemd.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	. "github.com/moshloop/konfigadm/pkg/utils"
+	. "github.com/flanksource/konfigadm/pkg/utils"
 )
 
 //Service is a systemd service to be installed and started

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"strings"
 
-	cloudinit "github.com/moshloop/konfigadm/pkg/cloud-init"
-	"github.com/moshloop/konfigadm/pkg/utils"
+	cloudinit "github.com/flanksource/konfigadm/pkg/cloud-init"
+	"github.com/flanksource/konfigadm/pkg/utils"
 )
 
 var (

--- a/test/merge_test.go
+++ b/test/merge_test.go
@@ -4,8 +4,8 @@ import (
 	"strings"
 	"testing"
 
-	_ "github.com/moshloop/konfigadm/pkg"
-	"github.com/moshloop/konfigadm/pkg/types"
+	_ "github.com/flanksource/konfigadm/pkg"
+	"github.com/flanksource/konfigadm/pkg/types"
 
 	"github.com/onsi/gomega"
 )


### PR DESCRIPTION
Fixes #17 

this changes all the references from github.com/moshloop/konfigadm
to github.com/flanksource/konfigadm in all go files and in go.mod
too