### PR TITLE
fix release download url and bump version

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,18 +3,18 @@
 ### Ubuntu / Debian
 
 ```bash
-wget https://github.com/moshloop/konfigadm/releases/download/v0.4.2/konfigadm.deb
+wget https://github.com/flanksource/konfigadm/releases/download/v0.5.3/konfigadm.deb
 dpkg -i konfigadm.deb
 ```
 
 ### Centos / Fedora / Redhat
 
 ```bash
-rpm -i https://github.com/moshloop/konfigadm/releases/download/v0.4.2/konfigadm.rpm
+rpm -i https://github.com/flanksource/konfigadm/releases/download/v0.5.3/konfigadm.rpm
 ```
 
 ### Binary
 
 ```bash
-wget -O /usr/bin/konfigadm https://github.com/moshloop/konfigadm/releases/download/v0.4.2/konfigadm && chmod +x /usr/bin/konfigadm
+wget -O /usr/bin/konfigadm https://github.com/flanksource/konfigadm/releases/download/v0.5.3/konfigadm && chmod +x /usr/bin/konfigadm
 ```


### PR DESCRIPTION
I think version bump could be automated by using the tag in the URL like some template of sorts