### PR TITLE
remove docs target from all target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ ifeq ($(VERSION),)
 VERSION := $(shell git describe --tags)
 endif
 
-all: test docs integration
+all: test integration
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
fixes #34 . this is due to the fact that docs target
tries to push to the main repo and not everyone has
access to it, but they will run make and hit an error
due to this