### PR TITLE
Increase timeout of integration tests

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -14,6 +14,6 @@ cleanup() {
 docker cp $PWD $container:/$(dirname $PWD)
 trap cleanup EXIT
 mkdir -p test-output
-go test -v ./test -race -coverprofile=integ.txt -covermode=atomic $args -timeout=20m | tee e2e.out
+go test -v ./test -race -coverprofile=integ.txt -covermode=atomic $args -timeout=30m | tee e2e.out
 set -euxo pipefail
 cat e2e.out | go2xunit --fail -output test-output/$(date +%Y%m%d%M%H%M%S).xml


### PR DESCRIPTION
With the introduction of the kernel tests, the duration of the integration
tests now exceeds 20 min on photon.  Increase the timeout to 30min to prevent
false negatives.