### PR TITLE
Fix documentation typo/syntax issue

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,5 +8,5 @@ Pre-commands are used to prepare the environment for execution, OS detection and
 #### commands
 Phases can only append to this Commands list.
 
-#### pre_commands
+#### post_commands
 Post commands run after all the phases have completed and can be used for cleanup functions are for handing off to other systems.

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,4 +1,4 @@
-#Environment
+# Environment
 
 Environment variables are saved to `/etc/environment/` and are sourced before any commands runs.
 ```yaml


### PR DESCRIPTION
The post commands are not named `pre_command` and Markdown requires a space between the `#` and the heading