### PR TITLE
Implememt Ansible inventry SSH commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,47 @@
-## Contributing
+# Contributing
+
+## Signing the CLA
+
+Please sign the CLA over [here](https://cla-assistant.io/flanksource/konfigadm)
+before contributing. Link -
+
+https://cla-assistant.io/flanksource/konfigadm
+
+## Developing
+
+Konfigadm is designed to make changes to the machine it runs on by default. This
+means that testing changes locally requires running within some sort of
+container or VM. This guide will use a systemd-nspawn container for rapid
+feedback. For running tests in the same way as the CI pipeline does, see 
+[Testing](#testing).
+
+```
+sudo debootstrap buster /var/lib/machines/konfigadm-debian-buster/
+sudo systemd-nspawn -D /var/lib/machines/konfigadm-debian-buster/ --machine konfigadm
+```
+
+This should present a console prompt on the container. Here we will configure
+the root password so that we can boot the container later. You can close the
+container by pressing `Ctrl + ]]]`.
+
+```
+passwd
+```
+
+Back on the host, run the following from within the Kubeadm directory to boot
+the container so that Konfigadm can run:
+
+```
+make linux
+sudo systemd-nspawn -D /var/lib/machines/konfigadm-debian-stable --machine konfigadm --bind-ro $(pwd):/opt/konfigadm
+cd /opt/konfigadm
+.bin/konfigadm --help
+```
+
+Now you can make changes and build locally and then run the resulting binary
+within the container to verify progress.
+
+## Testing
 
 Make sure both unit and integration tests pass:
 
@@ -17,9 +60,3 @@ And only integration tests via:
 ```bash
 make e2e-all
 ```
-
-### Signing the CLA
-
-Please sign the CLA over [here](https://cla-assistant.io/flanksource/konfigadm) before contributing. Link -
-
-https://cla-assistant.io/flanksource/konfigadm

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/flanksource/konfigadm/pkg/ansible"
+	"github.com/flanksource/konfigadm/pkg/types"
 	"github.com/flanksource/konfigadm/pkg/utils"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -15,60 +17,80 @@ import (
 var (
 	Apply = cobra.Command{
 		Use:   "apply",
-		Short: "Apply the configuration to the local machine",
+		Short: "Apply the configuration to the local machine or remote machines over SSH",
 		Args:  cobra.MinimumNArgs(0),
 		Run: func(cmd *cobra.Command, args []string) {
 			cfg := GetConfig(cmd, args)
 
-			files, commands, err := cfg.ApplyPhases()
-			if err != nil {
-				panic(err)
-			}
-
-			for path, file := range files {
-				log.Infof("Writing %s\n", utils.LightGreenf(path))
-				perms, _ := strconv.Atoi(file.Permissions)
-				if perms == 0 {
-					perms = 0644
+			var remoteHosts []string
+			if inventory, _ := cmd.Flags().GetString("inventory"); inventory != "" {
+				remoteHosts = ansible.ParseInventory(inventory)
+				cmd, err := cfg.ToBash()
+				if err != nil {
+					panic(err)
 				}
-				content := []byte(file.Content)
-				if file.Content == "" && file.ContentFromURL != "" {
-					log.Infof("Downloading %s to path %s", file.ContentFromURL, path)
-					resp, err := http.Get(file.ContentFromURL)
-					if err != nil {
-						log.Errorf("Failed to download from url %s: %v", file.ContentFromURL, err)
-						continue
-					}
-					defer resp.Body.Close()
-					c, err := ioutil.ReadAll(resp.Body)
-					if err != nil {
-						log.Errorf("Failed to read response body from url %s: %v", file.ContentFromURL, err)
-						continue
-					}
-					content = c
+				for _, host := range remoteHosts {
+					ansible.ExecuteRemoteCommand(cmd, host)
 				}
-
-				dirMode := perms + 111
-				dirName := filepath.Dir(path)
-				if _, serr := os.Stat(dirName); serr != nil {
-					merr := os.MkdirAll(dirName, os.FileMode(dirMode))
-					if merr != nil {
-						log.Errorf("Failed to mkdir %s: %v", utils.Redf(dirName), err)
-					}
-				}
-
-				if err := ioutil.WriteFile(path, []byte(content), os.FileMode(perms)); err != nil {
-					log.Errorf("Failed to write file %s: %v", utils.Redf(path), err)
-				}
-			}
-
-			for _, cmd := range commands {
-				log.Infof("Executing %s\n", utils.LightGreenf(cmd.Cmd))
-				if err := utils.Exec(cmd.Cmd); err != nil {
-					log.Fatalf("Failed to run: %s, %s", cmd.Cmd, err)
-				}
+			} else {
+				runLocal(cfg)
 			}
 
 		},
 	}
 )
+
+func runLocal(cfg *types.Config) {
+	files, commands, err := cfg.ApplyPhases()
+	if err != nil {
+		panic(err)
+	}
+
+	for path, file := range files {
+		log.Infof("Writing %s\n", utils.LightGreenf(path))
+		perms, _ := strconv.Atoi(file.Permissions)
+		if perms == 0 {
+			perms = 0644
+		}
+		content := []byte(file.Content)
+		if file.Content == "" && file.ContentFromURL != "" {
+			log.Infof("Downloading %s to path %s", file.ContentFromURL, path)
+			resp, err := http.Get(file.ContentFromURL)
+			if err != nil {
+				log.Errorf("Failed to download from url %s: %v", file.ContentFromURL, err)
+				continue
+			}
+			defer resp.Body.Close()
+			c, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				log.Errorf("Failed to read response body from url %s: %v", file.ContentFromURL, err)
+				continue
+			}
+			content = c
+		}
+
+		dirMode := perms + 111
+		dirName := filepath.Dir(path)
+		if _, serr := os.Stat(dirName); serr != nil {
+			merr := os.MkdirAll(dirName, os.FileMode(dirMode))
+			if merr != nil {
+				log.Errorf("Failed to mkdir %s: %v", utils.Redf(dirName), err)
+			}
+		}
+
+		if err := ioutil.WriteFile(path, []byte(content), os.FileMode(perms)); err != nil {
+			log.Errorf("Failed to write file %s: %v", utils.Redf(path), err)
+		}
+	}
+
+	for _, cmd := range commands {
+		log.Infof("Executing %s\n", utils.LightGreenf(cmd.Cmd))
+		if err := utils.Exec(cmd.Cmd); err != nil {
+			log.Fatalf("Failed to run: %s, %s", cmd.Cmd, err)
+		}
+	}
+}
+
+func init() {
+	Apply.Flags().String("inventory", "", "An ansible inventory to apply the configuration to")
+}

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -25,12 +25,13 @@ var (
 			var remoteHosts []string
 			if inventory, _ := cmd.Flags().GetString("inventory"); inventory != "" {
 				remoteHosts = ansible.ParseInventory(inventory)
+				port, _ := cmd.Flags().GetInt("port")
 				cmd, err := cfg.ToBash()
 				if err != nil {
 					panic(err)
 				}
 				for _, host := range remoteHosts {
-					ansible.ExecuteRemoteCommand(cmd, host)
+					ansible.ExecuteRemoteCommand(cmd, host, port)
 				}
 			} else {
 				runLocal(cfg)
@@ -93,4 +94,5 @@ func runLocal(cfg *types.Config) {
 
 func init() {
 	Apply.Flags().String("inventory", "", "An ansible inventory to apply the configuration to")
+	Apply.Flags().Int("port", 22, "The SSH port to use for applying the configuration remotely. Defaults to port 22")
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ Usage:
   konfigadm [command]
 
 Available Commands:
-  apply       Apply the configuration to the local machine
+  apply       Apply the configuration to the local machine or to remove machines over SSH
   cloud-init  Exports the configuration in cloud-init format
   help        Help about any command
   minify      Resolve all lookups and dependencies and export a single config file

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -62,7 +62,8 @@ ignored. Further, hostname ranges, such as `ww[0-5].example.com` are not
 supported. `konfigadm` assumes several things:
 
 1. The SSH user is root
-1. SSH key authentication uses an SSH agent
+1. SSH key authentication uses an SSH agent or `~/.ssh/id_rsa` does not require
+   a password
 1. The SSH port is 22
 
 The inventory can be used by invoking:

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -64,7 +64,8 @@ supported. `konfigadm` assumes several things:
 1. The SSH user is root
 1. SSH key authentication uses an SSH agent or `~/.ssh/id_rsa` does not require
    a password
-1. The SSH port is 22
+1. The SSH port is the same for all hosts. The port defaults to 22, but can be
+   changed using the `--port` command-line flag
 
 The inventory can be used by invoking:
 

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -3,7 +3,9 @@
 `konfigadm` can be used to wrap any other configuration management tool, it  has the advantage of being able to install the configuration management tool, copy the resources required for the tool and execute the tool all in one convenient package.
 
 
-## ansible
+# Ansible
+
+## Playbooks
 
 `config.yml`
 ```yaml
@@ -49,4 +51,22 @@ commands:
         copy:
           content: hello world
           dest: /tmp/testfile.txt
+```
+
+## Inventory
+
+Ansible inventory files can be used to run `konfigadm` against remote hosts
+over SSH. This is supported for the [INI inventory format](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#inventory-basics-formats-hosts-and-groups).
+All hosts in the file will be configured and all variables included will be
+ignored. Further, hostname ranges, such as `ww[0-5].example.com` are not
+supported. `konfigadm` assumes several things:
+
+1. The SSH user is root
+1. SSH key authentication uses an SSH agent
+1. The SSH port is 22
+
+The inventory can be used by invoking:
+
+```
+konfigadm apply -i ./inventory -c config.yml
 ```

--- a/pkg/ansible/inventory.go
+++ b/pkg/ansible/inventory.go
@@ -1,0 +1,56 @@
+package ansible
+
+import (
+	"bufio"
+	"path/filepath"
+	"os"
+	"strings"
+	log "github.com/sirupsen/logrus"
+)
+
+func ParseInventory(inventory string) []string {
+	inventory = filepath.Clean(inventory)
+	log.Infof("Reading inventory %s\n", inventory)
+	f, err := os.Open(inventory)
+	if err != nil {
+		panic(err)
+	}
+
+	defer func() {
+		if err = f.Close(); err != nil {
+			panic(err)
+		}
+	}()
+
+	s := bufio.NewScanner(f)
+	remoteHosts := make([]string, 0)
+	isChildGroup := false
+	for s.Scan() {
+		line := strings.Split(s.Text(), " ")[0] // Ignore all set host variables
+		if strings.HasSuffix(line, ":children]") { // Ignore child groups completely
+			isChildGroup = true
+			continue
+		} else if strings.HasPrefix(line, "[") { // Ignore group names
+			isChildGroup = false // Ends any previous child group
+			continue
+		}
+		if isChildGroup {
+			continue
+		}
+		if line == "" {
+			continue
+		}
+		duplicate := false
+		for _, host := range remoteHosts {
+			if host == line {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
+			continue
+		}
+		remoteHosts = append(remoteHosts, line)
+	}
+	return remoteHosts
+}

--- a/pkg/ansible/ssh.go
+++ b/pkg/ansible/ssh.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/flanksource/konfigadm/pkg/utils"
@@ -81,11 +82,10 @@ func SSHAgent() ssh.AuthMethod {
 	return ssh.PublicKeys(signer)
 }
 
-func ExecuteRemoteCommand(cmd string, host string) {
+func ExecuteRemoteCommand(cmd string, host string, port int) {
 	log.Infof("Executing %s on %s\n", utils.LightGreenf(cmd), host)
-	port := "22"
 	user := "root"
-
+	strPort := strconv.Itoa(port)
 	config := &ssh.ClientConfig{
 		User: user,
 		Auth: []ssh.AuthMethod{
@@ -95,7 +95,7 @@ func ExecuteRemoteCommand(cmd string, host string) {
 		Timeout:         5 * time.Second,
 	}
 
-	client, err := ssh.Dial("tcp", host+":"+port, config)
+	client, err := ssh.Dial("tcp", host+":"+strPort, config)
 	if err != nil {
 		log.Fatalf("Failed to run on %s: %s", host, err)
 	}

--- a/pkg/ansible/ssh.go
+++ b/pkg/ansible/ssh.go
@@ -1,0 +1,107 @@
+package ansible
+
+import (
+	"fmt"
+	"github.com/flanksource/konfigadm/pkg/utils"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/crypto/ssh/knownhosts"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func CheckKnownHosts() ssh.HostKeyCallback {
+	CreateKnownHosts()
+	knownHosts, err := knownhosts.New(filepath.Join(os.Getenv("HOME"), ".ssh", "known_hosts"))
+	if err != nil {
+		log.Fatalf("Failed to check known hosts: %s", err)
+	}
+	return knownHosts
+}
+
+func CreateKnownHosts() {
+	f, err := os.OpenFile(filepath.Join(os.Getenv("HOME"), ".ssh", "known_hosts"), os.O_CREATE, 0600)
+	if err != nil {
+		log.Fatalf("Failed to create known hosts file: %s", err)
+	}
+	f.Close()
+}
+
+func AddHostKey(host string, remote net.Addr, pubKey ssh.PublicKey) error {
+	knownHosts := filepath.Join(os.Getenv("HOME"), ".ssh", "known_hosts")
+	f, err := os.OpenFile(knownHosts, os.O_APPEND|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	fmt.Println(host)
+	newHost := knownhosts.Normalize(host)
+	newHost = knownhosts.HashHostname(newHost)
+	_, fErr := f.WriteString(knownhosts.Line([]string{newHost}, pubKey) + "\n")
+	return fErr
+}
+
+func VerifyHostKey(host string, remote net.Addr, pubKey ssh.PublicKey) error {
+	knownHosts := CheckKnownHosts()
+	err := knownHosts(host, remote, pubKey)
+	var hostErr *knownhosts.KeyError
+	if err != nil {
+		hostErr = err.(*knownhosts.KeyError)
+	}
+	if hostErr != nil && len(hostErr.Want) > 0 { // There are existing keys for this host
+		log.Warnf("key is not valid for %s, either a MiTM attack or %s has reconfigured the host pub key.", host, host)
+		return hostErr
+	} else if hostErr != nil && len(hostErr.Want) == 0 { // New host
+		log.Warnf("%s is not trusted, adding key to known_hosts file", host)
+		return AddHostKey(host, remote, pubKey)
+	}
+	log.Debugf("Public key exists for %s", host)
+	return nil
+}
+
+func SSHAgent() ssh.AuthMethod {
+	if sshAgent, err := net.Dial("unix", os.Getenv("SSH_AUTH_SOCK")); err == nil {
+		return ssh.PublicKeysCallback(agent.NewClient(sshAgent).Signers)
+	}
+	return nil
+}
+
+func ExecuteRemoteCommand(cmd string, host string) {
+	log.Infof("Executing %s on %s\n", utils.LightGreenf(cmd), host)
+	port := "22"
+	user := "root"
+
+	config := &ssh.ClientConfig{
+		User: user,
+		Auth: []ssh.AuthMethod{
+			SSHAgent(),
+		},
+		HostKeyCallback: VerifyHostKey,
+		Timeout:         5 * time.Second,
+	}
+
+	client, err := ssh.Dial("tcp", host+":"+port, config)
+	if err != nil {
+		log.Fatalf("Failed to run on %s: %s", host, err)
+	}
+	defer client.Close()
+	sess, err := client.NewSession()
+	if err != nil {
+		log.Fatalf("Failed to run on %s: %s", host, err)
+	}
+	defer sess.Close()
+
+	// setup standard out and error
+	// uses writer interface
+	sess.Stdout = os.Stdout
+	sess.Stderr = os.Stderr
+
+	// run single command
+	err = sess.Run(cmd)
+	if err != nil {
+		log.Fatalf("Failed to run on %s: %s", host, err)
+	}
+}

--- a/resources/static.go
+++ b/resources/static.go
@@ -213,7 +213,7 @@ var _escData = map[string]*_escFile{
 		name:    "const.go",
 		local:   "resources/const.go",
 		size:    203,
-		modtime: 1603465288,
+		modtime: 1609832440,
 		compressed: `
 H4sIAAAAAAAC/3TMsQrCMBCH8b1PETpZkPoEThUXcQq4X9N/Q2x7J3dJnl9QcBC6f7/vRWGhCKcwKRpg
 TVNJ3SCcKTF08tCaAtzZXf29WPZZE8fDTKvh6NpT+JW9fdO2+yxuZcSKPAjPu3gpI2ja/uRjNp9FKeKi
@@ -225,7 +225,7 @@ qUJ3+UTYhPunCbdd8w4AAP//P7XeAcsAAAA=
 		name:    "containerd.service",
 		local:   "resources/containerd.service",
 		size:    1421,
-		modtime: 1595862957,
+		modtime: 1609832440,
 		compressed: `
 H4sIAAAAAAAC/7xUwW7cNhC98ysG0aFA0ZVaoGnrADoksYsGjbuGnSIHwweKHK2mpjgCZ2h7+/UFufau
 UPhY9CSJmnnz5r0Hmts/I+mdaeBGbVJwHNVSxOTBCgSrWJ4Li9AQEB5JJ0goCzoFZXCBs99QJP1GTAMD
@@ -246,7 +246,7 @@ Zx+31xenoy9W7uXSPp1O/gkAAP//LPoJ6o0FAAA=
 		name:    "daemon.json",
 		local:   "resources/daemon.json",
 		size:    29,
-		modtime: 1603465288,
+		modtime: 1609832440,
 		compressed: `
 H4sIAAAAAAAC/6rmUlBQKi7JL0pMT9VNKcosSy1SslJQKksrVuKqBQQAAP//uMYVpR0AAAA=
 `,
@@ -256,7 +256,7 @@ H4sIAAAAAAAC/6rmUlBQKi7JL0pMT9VNKcosSy1SslJQKksrVuKqBQQAAP//uMYVpR0AAAA=
 		name:    "kubeadm.service",
 		local:   "resources/kubeadm.service",
 		size:    900,
-		modtime: 1595862957,
+		modtime: 1609832440,
 		compressed: `
 H4sIAAAAAAAC/3xSUW+bQAx+51dYtG8roLxOykO20Wrqlk1JJk2apsqAIW6Pu8hnaPn300FpEzXdE8b3
 +fPnz76AtVP6CLs9e6jEHdiCs2aARycPHh5Z9/DQFYRVC2irMTak0C/SxeJD9GdL0nNJf6Pc9izOtmR1


### PR DESCRIPTION
This implements a simple ansible inventory parser and uses that to run commands and copy files over SSH to remote hosts. Fixes: #74. It makes several assumptions around the SSH connection:

1. It uses SSH public key authentication with no support for password-based auth
1. The public key auth uses a SSH agent, available at `$SSH_AUTH_SOCK` or a passwordless `~/.ssh/id_rsa`
1. The remote user is `root` and the port is `22`.

There are also limitations on the inventory file:

1. Only supports INI file inventories, yaml files are not supported
1. Hostname ranges are not supported (e.g. `www[0-5].example.com`
1. Host variables are ignored (e.g. `ansible_user` or `ansible_port`)

Further if one host fails a command, the run will be aborted for all hosts

Still to do:

- [x] Run remote commands
- [x] Copy files to remote host
- [x] Tests
- [x] Documentation