### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,7 +12,7 @@ jobs:
         id: vars
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           OVFTOOL_LOCATION: ${{secrets.OVFTOOL_LOCATION}}
           KONFIGADM_VERSION: ${{ steps.vars.outputs.tag }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore